### PR TITLE
Harden GitHub repository governance and release controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+* @mpol1t
+
+.github/workflows/* @mpol1t
+Dockerfile @mpol1t
+scripts/* @mpol1t
+plugins/* @mpol1t

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a defect in the image, build, runtime behavior, or release process
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not use this template for private security disclosures. Follow the guidance in `SECURITY.md`.
+  - type: input
+    id: image_tag
+    attributes:
+      label: Image tag or digest
+      description: Include the exact tag or digest if known
+      placeholder: mpolit/rabbitmq-dedup:latest
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the problem clearly
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide the exact steps or commands to reproduce the issue
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Docker version, host OS, architecture, and any other relevant details
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security reporting guidance
+    url: https://github.com/mpol1t/rabbitmq-dedup/blob/main/SECURITY.md
+    about: Do not disclose suspected vulnerabilities publicly. Follow the private reporting guidance first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Propose an improvement to the image, release flow, or repository tooling
+title: "[feature] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What limitation or pain point are you trying to solve
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the change you want
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: List any alternatives or workarounds you evaluated
+    validations:
+      required: false
+  - type: textarea
+    id: impact
+    attributes:
+      label: Operational impact
+      description: Note any compatibility, release, or maintenance implications
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- what changed
+- why it changed
+
+## Verification
+
+- commands run
+- relevant outputs or observations
+
+## Risk
+
+- operational risk
+- release or workflow impact
+- follow-up work if any

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -88,6 +88,7 @@ jobs:
     needs:
       - build-test
     if: github.event_name == 'push'
+    environment: dockerhub
     permissions:
       contents: read
       id-token: write

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+## Workflow
+
+All changes to `main` must go through a pull request.
+
+Repository policy expects:
+
+- no direct pushes to `main`
+- no force pushes to `main`
+- rebase merge as the only merge method
+- clean commit history on pull request branches before merge
+
+Force-pushing feature branches is acceptable when cleaning up branch history for review.
+
+## Before Opening a Pull Request
+
+Run the repository checks locally where applicable:
+
+```bash
+docker build -t rabbitmq-dedup:local .
+./scripts/validate-release.sh
+./scripts/smoke-test.sh rabbitmq-dedup:local
+docker scout cves rabbitmq-dedup:local --only-severity critical,high --format packages
+```
+
+If your change affects vendored plugins, also run:
+
+```bash
+./scripts/update-plugins.sh
+```
+
+## Commit Expectations
+
+Keep commits logical and reviewable.
+
+Preferred characteristics:
+
+- one concern per commit where practical
+- commit messages in lowercase
+- no placeholder or exploratory commits left in the branch before merge
+
+## Pull Request Expectations
+
+Pull requests should:
+
+- explain the user-visible or operational impact
+- describe any release-process or workflow impact
+- mention any follow-up work or limitations
+- include verification notes
+
+Changes affecting these paths deserve extra care:
+
+- `.github/workflows/`
+- `Dockerfile`
+- `scripts/`
+- `plugins/`
+
+## Release Tags
+
+Immutable release publication is driven by Git tags matching:
+
+```text
+v<major>.<minor>.<patch>
+```
+
+Example:
+
+```bash
+git tag -a v4.2.7 -m "rabbitmq-dedup 4.2.7"
+git push origin v4.2.7
+```
+
+Do not create or move release tags casually.
+
+## Security
+
+If your change affects workflow security, release provenance, image publication, or credentials handling, call that out explicitly in the pull request.
+
+For suspected vulnerabilities, follow [SECURITY.md](SECURITY.md) instead of opening a public issue with exploit details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Scope
+
+This repository publishes a public Docker image for RabbitMQ with the message deduplication plugin pre-installed.
+
+Supported image line:
+
+- `4.2.x-alpine`
+
+Older tags may remain visible for historical reasons, but only the current supported line should be assumed to receive security and maintenance updates.
+
+## Reporting a Vulnerability
+
+Do not open public GitHub issues for suspected security vulnerabilities.
+
+Report vulnerabilities privately by using GitHub's security advisory workflow for this repository if available. If that is not available or appropriate, contact the maintainer directly through a private channel before public disclosure.
+
+When reporting, include:
+
+- affected image tag or digest
+- a clear description of the issue
+- reproduction steps if applicable
+- impact assessment
+- any known mitigations or upstream references
+
+## Response Expectations
+
+Target expectations:
+
+- initial triage acknowledgement within 7 days
+- confirmation of severity and scope as soon as reasonably possible
+- coordinated disclosure after a fix, mitigation, or clear operational guidance is available
+
+These are targets, not guarantees.
+
+## Upstream Dependencies
+
+Some security issues may originate in:
+
+- the official RabbitMQ base image
+- Alpine packages
+- vendored RabbitMQ plugin artifacts
+- GitHub Actions or release workflow dependencies
+
+Where the issue is upstream, fixes may depend on upstream releases or repository-specific mitigations.


### PR DESCRIPTION

## Summary

This PR hardens the repository and release path so that changes to `main` and Docker Hub publication are controlled by explicit GitHub rules and review requirements.

## Changes

- Added `.github/CODEOWNERS`, `SECURITY.md`, and `CONTRIBUTING.md`
- Added PR and issue templates
- Added `.github/dependabot.yml` for weekly GitHub Actions and Docker updates
- Bound the publish job to the protected `dockerhub` environment

## GitHub Configuration

- Protected `main` with PR-only, rebase-only rules
- Required approval, code owner review, resolved conversations, and CI checks
- Blocked force-pushes and branch deletion on `main`
- Enabled automatic branch deletion after merge
- Created a `dockerhub` environment restricted to `main` and `v*`
- Moved Docker Hub credentials from repository secrets to environment secrets
- Protected `refs/tags/v*` so release tags are maintainer-controlled
- Restricted Actions to selected actions and required SHA pinning
- Disabled Wiki and Projects

## Verification

Verified with `gh` that:

- `main` is PR-only and rebase-only
- release tags are protected
- Docker Hub secrets exist only in the `dockerhub` environment
- only `main` and `v*` can deploy to that environment
- selected-actions policy and SHA pinning are active
- Wiki and Projects are disabled

## Notes

- GitHub rulesets, environment policies, and Actions settings are part of this change even though they are not normal file diffs
- `GITHUB_HARDENING_PLAN.md` was used during implementation and is intentionally not part of this branch
